### PR TITLE
feat: add eqJson

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ test.new(std.thisFile)
   * [`fn new(name, test)`](#fn-casenew)
 * [`obj expect`](#obj-expect)
   * [`fn eq(actual, expected)`](#fn-expecteq)
+  * [`fn eqJson(actual, expected)`](#fn-expecteqjson)
   * [`fn ge(actual, expected)`](#fn-expectge)
   * [`fn gt(actual, expected)`](#fn-expectgt)
   * [`fn le(actual, expected)`](#fn-expectle)
@@ -58,8 +59,8 @@ suite.
 Output on success:
 
 ```
-$ jsonnet -J path/to/testonnet test.jsonnet
-TRACE: path/to/testonnet/main.libsonnet:74 Testing suite test.jsonnet
+$ jsonnet -J vendor/ test.jsonnet
+TRACE: testonnet/main.libsonnet:74 Testing suite test.jsonnet
 {
    "verify": "Passed 3 test cases"
 }
@@ -67,16 +68,16 @@ TRACE: path/to/testonnet/main.libsonnet:74 Testing suite test.jsonnet
 
 Output on failure:
 ```
-$ jsonnet -J path/to/testonnet test.jsonnet
-TRACE: path/to/testonnet/main.libsonnet:74 Testing suite test.jsonnet
+$ jsonnet -J vendor/ test.jsonnet
+TRACE: testonnet/main.libsonnet:74 Testing suite test.jsonnet
 RUNTIME ERROR: Failed 3/3 test cases:
 testFoo: Expected 1 to be 2
 testBar: Expected 1 to satisfy the function
 testBaz: Expected 1 to satisfy the condition that the value is between 2 and 3
-      path/to/testonnet/main.libsonnet:(78:11)-(84:13)	thunk from <object <anonymous>>
-      path/to/testonnet/main.libsonnet:(74:7)-(87:8)	object <anonymous>
-      Field "verify"	
-      During manifestation	
+      testonnet/main.libsonnet:(78:11)-(84:13)	thunk from <object <anonymous>>
+      testonnet/main.libsonnet:(74:7)-(87:8)	object <anonymous>
+      Field "verify"
+      During manifestation
 ```
 
 
@@ -102,6 +103,19 @@ eq(actual, expected)
 ```
 
 `eq` test for value equality
+
+Arguments:
+* `actual`: (any) The actual value.
+* `expected`: (any) The expected value to satisfy this test.
+
+
+#### fn expect.eqJson
+
+```ts
+eqJson(actual, expected)
+```
+
+`eqJson` test for JSON object equality with pretty print
 
 Arguments:
 * `actual`: (any) The actual value.
@@ -201,4 +215,3 @@ Arguments:
     Returns boolean if `actual` satisfies `expected`.
 * `message`: (fuction(actual, expected) string)
     Returns error message `actual` satisfies `expected`.
-

--- a/expect.libsonnet
+++ b/expect.libsonnet
@@ -58,6 +58,16 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       'Expected ' + actual + ' to be ' + expected,
   ),
 
+  '#eqJson':: docstring('eqJson', 'JSON object equality with pretty print'),
+  eqJson: self.new(
+    function(actual, expected) actual == expected,
+    function(actual, expected)
+      '\nActual:\n'
+      + std.manifestJson(actual)
+      + '\nExpected:\n'
+      + std.manifestJson(expected),
+  ),
+
   '#neq':: docstring('neq', 'value inequality'),
   neq: self.new(
     function(actual, expected) actual != expected,


### PR DESCRIPTION
I found the eqJson function in the training guide to be quite useful https://github.com/jsonnet-libs/jsonnet-training-course/blob/master/_gen/lesson6.md, so I made this PR to add it to the library.
I wonder if the output can show the diff between the expected and actual rather than just print both object. If I have some time I might try to implement it. In the mean time, this should be useful enough.